### PR TITLE
Add shutdown: false option to fire webhook without exiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,30 @@ Use `"shutdown_method"` to set a different HTTP method, e.g. for `POST`. You can
 }
 ```
 
+## Using a webhook instead of exiting
+
+By default, the plugin calls `sys.exit(0)` to shut down the Datasette process. If you'd prefer to have an external system handle the shutdown - for example, a cloud provider API or container orchestrator - you can set `"shutdown"` to `false`. This will cause the plugin to fire the `shutdown_url` webhook but **not** exit the process:
+
+```json
+{
+    "plugins": {
+        "datasette-scale-to-zero": {
+            "duration": "10m",
+            "shutdown_url": "https://api.example.com/instances/stop",
+            "shutdown_method": "POST",
+            "shutdown_headers": {
+                "Authorization": "Bearer token123",
+                "Content-Type": "application/json"
+            },
+            "shutdown_body": "{\"instance\": \"abc123\"}",
+            "shutdown": false
+        }
+    }
+}
+```
+
+The webhook will fire exactly once when the idle timeout or max age is reached. The process will continue running until the external system shuts it down.
+
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Use `"shutdown_method"` to set a different HTTP method, e.g. for `POST`. You can
 
 ## Using a webhook instead of exiting
 
-By default, the plugin calls `sys.exit(0)` to shut down the Datasette process. If you'd prefer to have an external system handle the shutdown - for example, a cloud provider API or container orchestrator - you can set `"shutdown"` to `false`. This will cause the plugin to fire the `shutdown_url` webhook but **not** exit the process:
+By default, the plugin calls `sys.exit(0)` to shut down the Datasette process. If you'd prefer to have an external system handle the shutdown - for example, a cloud provider API or container orchestrator - you can set `"exit"` to `false`. This will cause the plugin to fire the `shutdown_url` webhook but **not** exit the process:
 
 ```json
 {
@@ -127,7 +127,7 @@ By default, the plugin calls `sys.exit(0)` to shut down the Datasette process. I
                 "Content-Type": "application/json"
             },
             "shutdown_body": "{\"instance\": \"abc123\"}",
-            "shutdown": false
+            "exit": false
         }
     }
 }

--- a/datasette_scale_to_zero/__init__.py
+++ b/datasette_scale_to_zero/__init__.py
@@ -59,6 +59,9 @@ def start_that_loop(datasette):
                     should_exit = True
 
             if should_exit:
+                if getattr(datasette, "_scale_to_zero_fired", False):
+                    break
+                datasette._scale_to_zero_fired = True
                 # Avoid logging a traceback when the server exits
                 # https://github.com/simonw/datasette-scale-to-zero/issues/2
                 logger = logging.getLogger("uvicorn.error")
@@ -89,7 +92,8 @@ def do_exit(datasette):
     except Exception as e:
         print("Error sending shutdown request:", e, file=sys.stderr)
     finally:
-        sys.exit(0)
+        if config.get("shutdown", True):
+            sys.exit(0)
 
 
 def get_config(datasette):
@@ -103,6 +107,7 @@ def get_config(datasette):
     valid_keys = (
         "duration",
         "max_age",
+        "shutdown",
         "shutdown_url",
         "shutdown_headers",
         "shutdown_method",
@@ -168,6 +173,12 @@ def get_config(datasette):
         shutdown_body = raw_config["shutdown_body"]
         if not isinstance(shutdown_body, str):
             raise ValueError("shutdown_body must be a string")
+
+    if "shutdown" in raw_config:
+        shutdown = raw_config["shutdown"]
+        if not isinstance(shutdown, bool):
+            raise ValueError("shutdown must be a boolean (true or false)")
+        config["shutdown"] = shutdown
 
     for key in raw_config:
         if key.startswith("shutdown_"):

--- a/datasette_scale_to_zero/__init__.py
+++ b/datasette_scale_to_zero/__init__.py
@@ -66,13 +66,13 @@ def start_that_loop(datasette):
                 # https://github.com/simonw/datasette-scale-to-zero/issues/2
                 logger = logging.getLogger("uvicorn.error")
                 logger.disabled = True
-                loop.call_soon(do_exit, datasette)
+                loop.create_task(do_exit(datasette))
 
     loop = asyncio.get_running_loop()
     loop.create_task(check_if_server_should_exit())
 
 
-def do_exit(datasette):
+async def do_exit(datasette):
     config = get_config(datasette)
     try:
         if "shutdown_url" in config:
@@ -81,14 +81,16 @@ def do_exit(datasette):
             shutdown_method = config.get("shutdown_method", "GET")
             shutdown_headers = config.get("shutdown_headers", {})
             shutdown_body = config.get("shutdown_body", "")
-            method = getattr(httpx, shutdown_method.lower())
             kwargs = {}
             if shutdown_headers:
                 kwargs["headers"] = shutdown_headers
             if shutdown_body:
-                kwargs["data"] = shutdown_body
-            response = method(shutdown_url, **kwargs)
-            response.raise_for_status()
+                kwargs["content"] = shutdown_body
+            async with httpx.AsyncClient() as client:
+                response = await client.request(
+                    shutdown_method, shutdown_url, **kwargs
+                )
+                response.raise_for_status()
     except Exception as e:
         print("Error sending shutdown request:", e, file=sys.stderr)
     finally:

--- a/datasette_scale_to_zero/__init__.py
+++ b/datasette_scale_to_zero/__init__.py
@@ -92,7 +92,7 @@ async def do_exit(datasette):
     except Exception as e:
         print("Error sending shutdown request:", e, file=sys.stderr)
     finally:
-        if config.get("shutdown", True):
+        if config.get("exit", True):
             sys.exit(0)
 
 
@@ -107,7 +107,7 @@ def get_config(datasette):
     valid_keys = (
         "duration",
         "max_age",
-        "shutdown",
+        "exit",
         "shutdown_url",
         "shutdown_headers",
         "shutdown_method",
@@ -174,11 +174,11 @@ def get_config(datasette):
         if not isinstance(shutdown_body, str):
             raise ValueError("shutdown_body must be a string")
 
-    if "shutdown" in raw_config:
-        shutdown = raw_config["shutdown"]
-        if not isinstance(shutdown, bool):
-            raise ValueError("shutdown must be a boolean (true or false)")
-        config["shutdown"] = shutdown
+    if "exit" in raw_config:
+        exit_val = raw_config["exit"]
+        if not isinstance(exit_val, bool):
+            raise ValueError("exit must be a boolean (true or false)")
+        config["exit"] = exit_val
 
     for key in raw_config:
         if key.startswith("shutdown_"):

--- a/datasette_scale_to_zero/__init__.py
+++ b/datasette_scale_to_zero/__init__.py
@@ -87,9 +87,7 @@ async def do_exit(datasette):
             if shutdown_body:
                 kwargs["content"] = shutdown_body
             async with httpx.AsyncClient() as client:
-                response = await client.request(
-                    shutdown_method, shutdown_url, **kwargs
-                )
+                response = await client.request(shutdown_method, shutdown_url, **kwargs)
                 response.raise_for_status()
     except Exception as e:
         print("Error sending shutdown request:", e, file=sys.stderr)

--- a/tests/test_scale_to_zero.py
+++ b/tests/test_scale_to_zero.py
@@ -181,3 +181,61 @@ async def test_shutdown_pings_shutdown_url(mock_sys_exit, httpx_mock):
     assert request.url == "https://example.com/shutdown"
     assert request.headers["Authorization"] == "Bearer secret"
     assert request.content == b'{"message": "shutting down"}'
+
+
+@pytest.mark.asyncio
+async def test_shutdown_false_does_not_exit(mock_sys_exit, httpx_mock):
+    httpx_mock.add_response(url="https://example.com/shutdown")
+    datasette = Datasette(
+        memory=True,
+        plugin_config={
+            "datasette-scale-to-zero": {
+                "duration": "1s",
+                "shutdown_url": "https://example.com/shutdown",
+                "shutdown_method": "POST",
+                "shutdown": False,
+            }
+        },
+    )
+    await datasette.invoke_startup()
+    await datasette.client.get("/")
+    await asyncio.sleep(1.2)
+    # Webhook should have been called
+    request = httpx_mock.get_request()
+    assert request.method == "POST"
+    assert request.url == "https://example.com/shutdown"
+    # But sys.exit should NOT have been called
+    assert not mock_sys_exit.called
+
+
+@pytest.mark.asyncio
+async def test_shutdown_false_fires_webhook_only_once(mock_sys_exit, httpx_mock):
+    httpx_mock.add_response(url="https://example.com/shutdown")
+    datasette = Datasette(
+        memory=True,
+        plugin_config={
+            "datasette-scale-to-zero": {
+                "duration": "1s",
+                "shutdown_url": "https://example.com/shutdown",
+                "shutdown": False,
+            }
+        },
+    )
+    await datasette.invoke_startup()
+    await datasette.client.get("/")
+    # Wait long enough for multiple loop iterations
+    await asyncio.sleep(3)
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ("yes", 1, 0, "false"))
+async def test_shutdown_invalid_values(value):
+    with pytest.raises(ValueError) as ex:
+        ds = Datasette(
+            memory=True,
+            plugin_config={"datasette-scale-to-zero": {"shutdown": value}},
+        )
+        await ds.invoke_startup()
+    assert ex.value.args[0] == "shutdown must be a boolean (true or false)"

--- a/tests/test_scale_to_zero.py
+++ b/tests/test_scale_to_zero.py
@@ -184,7 +184,7 @@ async def test_shutdown_pings_shutdown_url(mock_sys_exit, httpx_mock):
 
 
 @pytest.mark.asyncio
-async def test_shutdown_false_does_not_exit(mock_sys_exit, httpx_mock):
+async def test_exit_false_does_not_exit(mock_sys_exit, httpx_mock):
     httpx_mock.add_response(url="https://example.com/shutdown")
     datasette = Datasette(
         memory=True,
@@ -193,7 +193,7 @@ async def test_shutdown_false_does_not_exit(mock_sys_exit, httpx_mock):
                 "duration": "1s",
                 "shutdown_url": "https://example.com/shutdown",
                 "shutdown_method": "POST",
-                "shutdown": False,
+                "exit": False,
             }
         },
     )
@@ -209,7 +209,7 @@ async def test_shutdown_false_does_not_exit(mock_sys_exit, httpx_mock):
 
 
 @pytest.mark.asyncio
-async def test_shutdown_false_fires_webhook_only_once(mock_sys_exit, httpx_mock):
+async def test_exit_false_fires_webhook_only_once(mock_sys_exit, httpx_mock):
     httpx_mock.add_response(url="https://example.com/shutdown")
     datasette = Datasette(
         memory=True,
@@ -217,7 +217,7 @@ async def test_shutdown_false_fires_webhook_only_once(mock_sys_exit, httpx_mock)
             "datasette-scale-to-zero": {
                 "duration": "1s",
                 "shutdown_url": "https://example.com/shutdown",
-                "shutdown": False,
+                "exit": False,
             }
         },
     )
@@ -231,11 +231,11 @@ async def test_shutdown_false_fires_webhook_only_once(mock_sys_exit, httpx_mock)
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("value", ("yes", 1, 0, "false"))
-async def test_shutdown_invalid_values(value):
+async def test_exit_invalid_values(value):
     with pytest.raises(ValueError) as ex:
         ds = Datasette(
             memory=True,
-            plugin_config={"datasette-scale-to-zero": {"shutdown": value}},
+            plugin_config={"datasette-scale-to-zero": {"exit": value}},
         )
         await ds.invoke_startup()
-    assert ex.value.args[0] == "shutdown must be a boolean (true or false)"
+    assert ex.value.args[0] == "exit must be a boolean (true or false)"


### PR DESCRIPTION
When `shutdown` is set to `false` in plugin config, the plugin fires
the shutdown_url webhook when idle timeout is reached but does NOT
call sys.exit(0). This allows an external system to handle the actual
shutdown. The webhook fires exactly once (guarded by a fired flag).

https://claude.ai/code/session_01GFRhTEqdyuFTAaRxtNwKbo